### PR TITLE
[autoconf]: Add inspec tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.autoconf?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=69&branchName=master)
+
 # autoconf
 
 ## Maintainers

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# autoconf
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+command_relative_path: '/bin/autoconf'

--- a/controls/autoconf_exists.rb
+++ b/controls/autoconf_exists.rb
@@ -7,7 +7,8 @@ control 'core-plans-autoconf-exists' do
   impact 1.0
   title 'Ensure autoconf exists'
   desc '
-  '
+  Verify autoconf by ensuring /bin/autoconf exists'
+  
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }

--- a/controls/autoconf_exists.rb
+++ b/controls/autoconf_exists.rb
@@ -1,0 +1,22 @@
+title 'Tests to confirm autoconf exists'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'autoconf')
+ 
+control 'core-plans-autoconf-exists' do
+  impact 1.0
+  title 'Ensure autoconf exists'
+  desc '
+  '
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+
+  command_relative_path = input('command_relative_path', value: '/bin/autoconf')
+  command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
+  describe file(command_full_path) do
+    it { should exist }
+  end
+end

--- a/controls/autoconf_works.rb
+++ b/controls/autoconf_works.rb
@@ -1,0 +1,25 @@
+title 'Tests to confirm autoconf works as expected'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'autoconf')
+
+control 'core-plans-autoconf-works' do
+  impact 1.0
+  title 'Ensure autoconf works as expected'
+  desc '
+  '
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  
+  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
+  describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} autoconf --version") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /autoconf \(GNU Autoconf\) #{plan_pkg_version}/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/controls/autoconf_works.rb
+++ b/controls/autoconf_works.rb
@@ -7,7 +7,10 @@ control 'core-plans-autoconf-works' do
   impact 1.0
   title 'Ensure autoconf works as expected'
   desc '
+  Verify autoconf by ensuring (1) its installation directory exists and (2) that
+  it returns the expected version
   '
+  
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,9 +1,9 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
-maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
-copyright: humans@habitat.sh
-copyright_email: humans@habitat.sh
+name: autoconf
+title: Habitat Core Plan autoconf
+maintainer: "The Habitat Maintainers <humans@habitat.sh>"
+summary: InSpec controls for testing Habitat Core Plan autoconf
+copyright: 2019, Chef Software, Inc.
+copyright_email: legal@chef.io
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 3.0.25'

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,41 @@
+pkg_name=autoconf
+pkg_origin=core
+pkg_version=2.69
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="\
+Autoconf is an extensible package of M4 macros that produce shell scripts to \
+automatically configure software source code packages.\
+"
+pkg_upstream_url="https://www.gnu.org/software/autoconf/autoconf.html"
+pkg_license=('GPL-2.0-or-later')
+pkg_source="http://ftp.gnu.org/gnu/${pkg_name}/${pkg_name}-${pkg_version}.tar.xz"
+pkg_shasum="64ebcec9f8ac5b2487125a86a7760d2591ac9e1d3dbd59489633f9de62a57684"
+pkg_deps=(
+  core/m4
+  core/perl
+)
+pkg_build_deps=(
+  core/diffutils
+  core/inetutils
+  core/gcc
+  core/make
+)
+pkg_bin_dirs=(bin)
+
+
+# ----------------------------------------------------------------------------
+# **NOTICE:** What follows are implementation details required for building a
+# first-pass, "stage1" toolchain and environment. It is only used when running
+# in a "stage1" Studio and can be safely ignored by almost everyone. Having
+# said that, it performs a vital bootstrapping process and cannot be removed or
+# significantly altered. Thank you!
+# ----------------------------------------------------------------------------
+if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+  pkg_build_deps=(
+    core/gcc
+    core/coreutils
+    core/sed
+    core/gawk
+    core/diffutils
+  )
+fi

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,4 @@
+@test "autoconf displays help" {
+  run hab pkg exec $TEST_PKG_IDENT autoconf --help
+  [ "$status" -eq 0 ]
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
```rspec
hab pkg exec chef/inspec inspec exec /src/. --chef-license=accept -t docker://ace5d02e0dd46e63b8490af32fd081d9d9775bd345d2ddf004e83247741746c4 --input-file /src/attributes.yml

Profile: Habitat Core Plan autoconf (autoconf)
Version: 0.1.0
Target:  docker://ace5d02e0dd46e63b8490af32fd081d9d9775bd345d2ddf004e83247741746c4

  ✔  core-plans-autoconf-exists: Ensure autoconf exists
     ✔  File /hab/pkgs/core/autoconf/2.69/20200603125914/bin/autoconf is expected to exist
  ✔  core-plans-autoconf-works: Ensure autoconf works as expected
     ✔  Command: `hab pkg path core/autoconf` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/autoconf` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/autoconf/2.69/20200603125914 autoconf --version` exit_status is expected to eq 0
     ✔  Command: `DEBUG=true; hab pkg exec core/autoconf/2.69/20200603125914 autoconf --version` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/autoconf/2.69/20200603125914 autoconf --version` stdout is expected to match /autoconf \(GNU Autoconf\) 2.69/
     ✔  Command: `DEBUG=true; hab pkg exec core/autoconf/2.69/20200603125914 autoconf --version` stderr is expected to be empty


Profile Summary: 2 successful controls, 0 control failures, 0 controls skipped
Test Summary: 7 successful, 0 failures, 0 skipped
+ set +x
```